### PR TITLE
Changed runner-type to python-script

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.4
+
+* Change runner type  from `run-python` to `python-script`
+
 ## v0.2.3
 
 * Following acos-client v1.4.1 to operate SLB ServerPort through the AxAPI v3.0

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ appliance:
     api_version: v3.0
 ```
 
+Copy [acos.yaml.example](./acos.yaml.example) to `/opt/stackstorm/configs/acos.yaml` and edit as required.
+
+After making changes to `acos.yaml`, you must tell StackStorm to load the new configuration, with
+`sudo st2ctl reload --register-configs`
+
 ## Actions
 | params                        | description                                                     |
 |:------------------------------|:----------------------------------------------------------------|

--- a/actions/add_slb_server.yaml
+++ b/actions/add_slb_server.yaml
@@ -1,6 +1,6 @@
 ---
 name: add_slb_server
-runner_type: run-python
+runner_type: python-script
 description: register a server to the SLB 
 enabled: true
 entry_point: ax_action_runner.py

--- a/actions/add_slb_server_port.yaml
+++ b/actions/add_slb_server_port.yaml
@@ -1,6 +1,6 @@
 ---
 name: add_slb_server_port
-runner_type: run-python
+runner_type: python-script
 description: register a server-port to the SLB
 enabled: true
 entry_point: ax_action_runner.py

--- a/actions/add_slb_service_group.yaml
+++ b/actions/add_slb_service_group.yaml
@@ -1,6 +1,6 @@
 ---
 name: add_slb_service_group
-runner_type: run-python
+runner_type: python-script
 description: register a ServiceGroup to the SLB 
 enabled: true
 entry_point: ax_action_runner.py

--- a/actions/add_slb_service_group_member.yaml
+++ b/actions/add_slb_service_group_member.yaml
@@ -1,7 +1,7 @@
 ---
 name: add_slb_service_group_member
 pack: acos
-runner_type: run-python
+runner_type: python-script
 description: add a server to the ServiceGroup as a member
 enabled: true
 entry_point: ax_action_runner.py

--- a/actions/add_slb_virtual_server.yaml
+++ b/actions/add_slb_virtual_server.yaml
@@ -1,7 +1,7 @@
 ---
 name: add_slb_virtual_server
 pack: acos
-runner_type: run-python
+runner_type: python-script
 description: Add a VirtualServer to SLB
 enabled: true
 entry_point: ax_action_runner.py

--- a/actions/add_slb_virtual_server_port.yaml
+++ b/actions/add_slb_virtual_server_port.yaml
@@ -1,7 +1,7 @@
 ---
 name: add_slb_virtual_server_port
 pack: acos
-runner_type: run-python
+runner_type: python-script
 description: Add a virtual-server-port to the SLB
 enabled: true
 entry_point: ax_action_runner.py

--- a/actions/del_slb_server.yaml
+++ b/actions/del_slb_server.yaml
@@ -1,6 +1,6 @@
 ---
 name: del_slb_server
-runner_type: run-python
+runner_type: python-script
 description: remove a server which is registered in SLB
 enabled: true
 entry_point: ax_action_runner.py

--- a/actions/del_slb_server_port.yaml
+++ b/actions/del_slb_server_port.yaml
@@ -1,6 +1,6 @@
 ---
 name: del_slb_server_port
-runner_type: run-python
+runner_type: python-script
 description: remove a server-port to the SLB
 enabled: true
 entry_point: ax_action_runner.py

--- a/actions/del_slb_service_group.yaml
+++ b/actions/del_slb_service_group.yaml
@@ -1,6 +1,6 @@
 ---
 name: del_slb_service_group
-runner_type: run-python
+runner_type: python-script
 description: remove a ServiceGroup from SLB
 enabled: true
 entry_point: ax_action_runner.py

--- a/actions/del_slb_service_group_member.yaml
+++ b/actions/del_slb_service_group_member.yaml
@@ -1,7 +1,7 @@
 ---
 name: del_slb_service_group_member
 pack: acos
-runner_type: run-python
+runner_type: python-script
 description: remove a server to the ServiceGroup as a member
 enabled: true
 entry_point: ax_action_runner.py

--- a/actions/del_slb_virtual_server.yaml
+++ b/actions/del_slb_virtual_server.yaml
@@ -1,7 +1,7 @@
 ---
 name: del_slb_virtual_server
 pack: acos
-runner_type: run-python
+runner_type: python-script
 description: remove a VirutlServer from SLB 
 enabled: true
 entry_point: ax_action_runner.py

--- a/actions/del_slb_virtual_server_port.yaml
+++ b/actions/del_slb_virtual_server_port.yaml
@@ -1,7 +1,7 @@
 ---
 name: del_slb_virtual_server_port
 pack: acos
-runner_type: run-python
+runner_type: python-script
 description: Remove virtual-server-port from the SLB
 enabled: true
 entry_point: ax_action_runner.py

--- a/actions/get_slb_server.yaml
+++ b/actions/get_slb_server.yaml
@@ -1,6 +1,6 @@
 ---
 name: get_slb_server
-runner_type: run-python
+runner_type: python-script
 description: get a Server information which is registered in SLB
 enabled: true
 entry_point: ax_action_runner.py

--- a/actions/get_slb_service_group.yaml
+++ b/actions/get_slb_service_group.yaml
@@ -1,6 +1,6 @@
 ---
 name: get_slb_service_group
-runner_type: run-python
+runner_type: python-script
 description: get a ServiceGroup information which is registered in SLB
 enabled: true
 entry_point: ax_action_runner.py

--- a/actions/get_slb_service_group_members.yaml
+++ b/actions/get_slb_service_group_members.yaml
@@ -1,7 +1,7 @@
 ---
 name: get_slb_service_group_members
 pack: acos
-runner_type: run-python
+runner_type: python-script
 description: get members information which are belonged to the ServiceGroup
 enabled: true
 entry_point: ax_action_runner.py

--- a/actions/get_slb_virtual_server.yaml
+++ b/actions/get_slb_virtual_server.yaml
@@ -1,7 +1,7 @@
 ---
 name: get_slb_virtual_server
 pack: acos
-runner_type: run-python
+runner_type: python-script
 description: get VirtualServer which is registered in the SLB
 enabled: true
 entry_point: ax_action_runner.py

--- a/actions/list_slb_servers.yaml
+++ b/actions/list_slb_servers.yaml
@@ -1,6 +1,6 @@
 ---
 name: list_slb_servers
-runner_type: run-python
+runner_type: python-script
 description: lists servers which are registered in SLB
 enabled: true
 entry_point: ax_action_runner.py

--- a/actions/list_slb_service_groups.yaml
+++ b/actions/list_slb_service_groups.yaml
@@ -1,6 +1,6 @@
 ---
 name: list_slb_service_groups
-runner_type: run-python
+runner_type: python-script
 description: lists ServiceGroup entries which are registered in SLB
 enabled: true
 entry_point: ax_action_runner.py

--- a/actions/list_slb_virtual_servers.yaml
+++ b/actions/list_slb_virtual_servers.yaml
@@ -1,7 +1,7 @@
 ---
 name: list_slb_virtual_servers
 pack: acos
-runner_type: run-python
+runner_type: python-script
 description: list VirtualServers which are registered in the SLB
 enabled: true
 entry_point: ax_action_runner.py

--- a/pack.yaml
+++ b/pack.yaml
@@ -7,6 +7,6 @@ keywords:
   - load balancer
   - ADC
   - network
-version: 0.2.3
+version: 0.2.4
 author: Hiroyasu OHYAMA
 email: user.localhost2000@gmail.com


### PR DESCRIPTION
I've changed the runner-type to `python-script`, as that is the preferred notation. `run-python` is a deprecated style. No other changes required to actions. 