### PR TITLE
Added actions to operate IP address of NAT Pool

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.2.0
+
+* Added actions to operate IP address of NAT pool
+
 ## v1.1.0
 
 * Update acos_client, which this pack depends on, version from v1.4.6 to v2.6.0

--- a/README.md
+++ b/README.md
@@ -29,16 +29,20 @@ After making changes to `acos.yaml`, you must tell StackStorm to load the new co
 | add_slb_service_group         | add a ServiceGroup to the SLB                              |
 | add_slb_virtual_server        | add a VirtualServer to SLB                                      |
 | add_slb_virtual_server_port   | add a VirtualServerPort to the VirtualServer in SLB             |
+| create_ip_nat_pool            | create configuration of IP address of NAT pool                  |
 | del_slb_server                | remove a server which is registered in SLB                      |
 | del_slb_server_port           | remove a ServerPort which is registered in SLB                  |
 | del_slb_service_group_member  | remove a server to the ServiceGroup as a member                 |
 | del_slb_service_group         | remove a ServiceGroup from SLB                                  |
 | del_slb_virtual_server        | remove a VirutlServer from SLB                                  |
 | del_slb_virtual_server_port   | remove a VirutlServerPort from the VirtualServer in SLB         |
+| delete_ip_nat_pool            | delete configuration of IP address of NAT pool                  |
+| get_ip_nat_pool               | get configuration of IP address of NAT pool                     |
 | get_slb_server                | get a Server information which is registered in SLB             |
 | get_slb_service_group_members | get members information which are belonged to the ServiceGroup  |
 | get_slb_service_group         | get a ServiceGroup information which is registered in SLB       |
 | get_slb_virtual_server        | get VirtualServer which is registered in the SLB                |
+| list_ip_nat_pool              | list configurations of IP address of NAT pool                   |
 | list_slb_servers              | lists servers which are registered in SLB                       |
 | list_slb_service_groups       | lists ServiceGroup entries which are registered in SLB          |
 | list_slb_virtual_servers      | list VirtualServers which are registered in the SLB             |

--- a/actions/create_ip_nat_pool.yaml
+++ b/actions/create_ip_nat_pool.yaml
@@ -1,0 +1,45 @@
+---
+name: create_ip_nat_pool
+runner_type: python-script
+description: create configuration of IP address of NAT pool
+enabled: true
+entry_point: ax_action_runner.py
+parameters:
+    action:
+        type: string
+        immutable: true
+        default: create
+    object_path:
+        type: string
+        immutable: true
+        default: nat.pool
+    one_target:
+        type: boolean
+        immutable: true
+        default: false
+    appliance:
+        type: string
+        description: The appliance information to connect, which is specified at the 'appliance' parameter in the configuration.
+    pool_name:
+        type: string
+        description: Pool name or pool group
+        required: true
+    start_address:
+        type: string
+        description: Start IP address of NAT pool
+        required: true
+    end_address:
+        type: string
+        description: End IP address of NAT pool
+        required: true
+    netmask:
+        type: string
+        description: Netmask for NAT pool
+        required: true
+    ip_rr:
+        type: boolean
+        description: IP address round-robin behavior
+        default: False
+    vrid:
+        type: integer
+        description: VRRP-A vrid (Specify ha VRRP-A vrid)

--- a/actions/delete_ip_nat_pool.yaml
+++ b/actions/delete_ip_nat_pool.yaml
@@ -1,0 +1,26 @@
+---
+name: delete_ip_nat_pool
+runner_type: python-script
+description: delete configuration of IP address of NAT pool
+enabled: true
+entry_point: ax_action_runner.py
+parameters:
+    action:
+        type: string
+        immutable: true
+        default: delete
+    object_path:
+        type: string
+        immutable: true
+        default: nat.pool
+    one_target:
+        type: boolean
+        immutable: true
+        default: false
+    appliance:
+        type: string
+        description: The appliance information to connect, which is specified at the 'appliance' parameter in the configuration.
+    name:
+        type: string
+        description: pool-name to delete IP address of NAT pool
+        required: true

--- a/actions/get_ip_nat_pool.yaml
+++ b/actions/get_ip_nat_pool.yaml
@@ -1,0 +1,26 @@
+---
+name: get_ip_nat_pool
+runner_type: python-script
+description: get configuration of IP address of NAT pool
+enabled: true
+entry_point: ax_action_runner.py
+parameters:
+    action:
+        type: string
+        immutable: true
+        default: get
+    object_path:
+        type: string
+        immutable: true
+        default: nat.pool
+    one_target:
+        type: boolean
+        immutable: true
+        default: false
+    appliance:
+        type: string
+        description: The appliance information to connect, which is specified at the 'appliance' parameter in the configuration.
+    name:
+        type: string
+        description: pool-name to get IP address of NAT pool
+        required: true

--- a/actions/list_ip_nat_pool.yaml
+++ b/actions/list_ip_nat_pool.yaml
@@ -1,0 +1,22 @@
+---
+name: list_ip_nat_pool
+runner_type: python-script
+description: list configurations of IP address of NAT pool
+enabled: true
+entry_point: ax_action_runner.py
+parameters:
+    action:
+        type: string
+        immutable: true
+        default: all
+    object_path:
+        type: string
+        immutable: true
+        default: nat.pool
+    one_target:
+        type: boolean
+        immutable: true
+        default: false
+    appliance:
+        type: string
+        description: The appliance information to connect, which is specified at the 'appliance' parameter in the configuration.

--- a/pack.yaml
+++ b/pack.yaml
@@ -7,7 +7,7 @@ keywords:
   - load balancer
   - ADC
   - network
-version: 1.1.0
+version: 1.2.0
 author: Hiroyasu OHYAMA
 email: user.localhost2000@gmail.com
 python_versions:


### PR DESCRIPTION
This commit adds following actions that configure pools of IP addresses for Network Address Translation.

* acos.create_ip_nat_pool
* acos.delete_ip_nat_pool
* acos.get_ip_nat_pool
* acos.list_ip_nat_pool