### PR TITLE
Add secified_target parameter to all actions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v1.2.0
+* Add `specified_target` parameter to all actions.
+
 ## v1.1.0
 
 * Update acos_client, which this pack depends on, version from v1.4.6 to v2.6.0

--- a/actions/acoslib/action.py
+++ b/actions/acoslib/action.py
@@ -9,7 +9,7 @@ class BaseAction(Action):
     DEFAULT_AXAPI_VERSION = acos.AXAPI_30
 
     # These are the parameters for acos pack, not used by the ACOS Client
-    PARAMS_FOR_PACK = ['appliance', 'action', 'object_path', 'one_target']
+    PARAMS_FOR_PACK = ['appliance', 'action', 'object_path', 'one_target', 'specified_target']
 
     def __init__(self, config):
         super(BaseAction, self).__init__(config)

--- a/actions/acoslib/action.py
+++ b/actions/acoslib/action.py
@@ -9,7 +9,7 @@ class BaseAction(Action):
     DEFAULT_AXAPI_VERSION = acos.AXAPI_30
 
     # These are the parameters for acos pack, not used by the ACOS Client
-    PARAMS_FOR_PACK = ['appliance', 'action', 'object_path', 'one_target', 'specified_target']
+    PARAMS_FOR_PACK = ['appliance', 'action', 'object_path', 'one_target']
 
     def __init__(self, config):
         super(BaseAction, self).__init__(config)
@@ -18,12 +18,12 @@ class BaseAction(Action):
 
         self.config = config
 
-    def login(self, appliance, specified_target=None):
+    def login(self, target, specified_target=None):
         try:
             if specified_target:
                 config = specified_target
             else:
-                config = next(x for x in self.config['appliance'] if x['target'] == appliance)
+                config = next(x for x in self.config['appliance'] if x['target'] == target)
             return acos.Client(config['target'],
                                config['api_version'],
                                config['userid'],
@@ -34,7 +34,7 @@ class BaseAction(Action):
             self.logger.error(e)
         except StopIteration:
             self.logger.error("Specified appliance(%s) doesn't exist in the configuration file " %
-                              appliance)
+                              target)
 
     def get_object(self, base_obj, object_path):
         obj = base_obj

--- a/actions/acoslib/action.py
+++ b/actions/acoslib/action.py
@@ -9,7 +9,7 @@ class BaseAction(Action):
     DEFAULT_AXAPI_VERSION = acos.AXAPI_30
 
     # These are the parameters for acos pack, not used by the ACOS Client
-    PARAMS_FOR_PACK = ['appliance', 'action', 'object_path', 'one_target']
+    PARAMS_FOR_PACK = ['appliance', 'action', 'object_path', 'one_target', 'specified_target']
 
     def __init__(self, config):
         super(BaseAction, self).__init__(config)
@@ -18,9 +18,12 @@ class BaseAction(Action):
 
         self.config = config
 
-    def login(self, appliance):
+    def login(self, appliance, specified_target=None):
         try:
-            config = next(x for x in self.config['appliance'] if x['target'] == appliance)
+            if specified_target:
+                config = specified_target
+            else:
+                config = next(x for x in self.config['appliance'] if x['target'] == appliance)
             return acos.Client(config['target'],
                                config['api_version'],
                                config['userid'],

--- a/actions/add_slb_server.yaml
+++ b/actions/add_slb_server.yaml
@@ -36,3 +36,6 @@ parameters:
         type: string
         description: The appliance information to connect, which is specified at the 'appliance' parameter in the configuration.
         required: true
+    specified_target:
+        type: object
+        description: "Specify the target dynamically, (key: 'target', 'api_version', 'userid', 'passwd')"

--- a/actions/add_slb_server_port.yaml
+++ b/actions/add_slb_server_port.yaml
@@ -36,3 +36,6 @@ parameters:
         type: string
         description: The appliance information to connect, which is specified at the 'appliance' parameter in the configuration.
         required: true
+    specified_target:
+        type: object
+        description: "Specify the target dynamically, (key: 'target', 'api_version', 'userid', 'passwd')"

--- a/actions/add_slb_service_group.yaml
+++ b/actions/add_slb_service_group.yaml
@@ -55,3 +55,6 @@ parameters:
         type: string
         description: The appliance information to connect, which is specified at the 'appliance' parameter in the configuration.
         required: true
+    specified_target:
+        type: object
+        description: "Specify the target dynamically, (key: 'target', 'api_version', 'userid', 'passwd')"

--- a/actions/add_slb_service_group_member.yaml
+++ b/actions/add_slb_service_group_member.yaml
@@ -41,3 +41,6 @@ parameters:
         type: string
         description: The appliance information to connect, which is specified at the 'appliance' parameter in the configuration.
         required: true
+    specified_target:
+        type: object
+        description: "Specify the target dynamically, (key: 'target', 'api_version', 'userid', 'passwd')"

--- a/actions/add_slb_virtual_server.yaml
+++ b/actions/add_slb_virtual_server.yaml
@@ -41,3 +41,6 @@ parameters:
         type: string
         description: The appliance information to connect, which is specified at the 'appliance' parameter in the configuration.
         required: true
+    specified_target:
+        type: object
+        description: "Specify the target dynamically, (key: 'target', 'api_version', 'userid', 'passwd')"

--- a/actions/add_slb_virtual_server_port.yaml
+++ b/actions/add_slb_virtual_server_port.yaml
@@ -71,3 +71,6 @@ parameters:
         type: string
         description: The appliance information to connect, which is specified at the 'appliance' parameter in the configuration.
         required: true
+    specified_target:
+        type: object
+        description: "Specify the target dynamically, (key: 'target', 'api_version', 'userid', 'passwd')"

--- a/actions/ax_action_runner.py
+++ b/actions/ax_action_runner.py
@@ -4,11 +4,10 @@ from acoslib.action import BaseAction
 
 
 class AXActionRunner(BaseAction):
-    def do_run(self, action, object_path, appliance, specified_target, **kwargs):
-        target = appliance
-        if specified_target:
-            target = specified_target.get("target")
-        client = self.login(appliance, specified_target)
+    def do_run(self, action, object_path, target, **kwargs):
+        if kwargs.get('specified_target'):
+            target = kwargs.get('specified_target').get("target")
+        client = self.login(target, kwargs.get('specified_target'))
         if client:
             try:
                 # transforms user parameters as needed
@@ -28,12 +27,10 @@ class AXActionRunner(BaseAction):
             return (False, '[%s] Failed to initilaize Client object of acos_client' % target)
 
     def run(self, action, object_path, one_target, **kwargs):
-        if one_target or kwargs.get('appliance') or kwargs.get('specified_target'):
-            return self.do_run(
-                action,
-                object_path,
-                **kwargs
-            )
+        if kwargs.get('specified_target'):
+            return self.do_run(action, object_path, None, **kwargs)
+        if one_target or kwargs.get('appliance'):
+            return self.do_run(action, object_path, kwargs.get('appliance'), **kwargs)
         else:
             results = []
             for config in self.config['appliance']:

--- a/actions/ax_action_runner.py
+++ b/actions/ax_action_runner.py
@@ -4,8 +4,11 @@ from acoslib.action import BaseAction
 
 
 class AXActionRunner(BaseAction):
-    def do_run(self, action, object_path, target, **kwargs):
-        client = self.login(target)
+    def do_run(self, action, object_path, appliance, specified_target, **kwargs):
+        target = appliance
+        if specified_target:
+            target = specified_target.get("target")
+        client = self.login(appliance, specified_target)
         if client:
             try:
                 # transforms user parameters as needed
@@ -25,8 +28,12 @@ class AXActionRunner(BaseAction):
             return (False, '[%s] Failed to initilaize Client object of acos_client' % target)
 
     def run(self, action, object_path, one_target, **kwargs):
-        if one_target or kwargs.get('appliance'):
-            return self.do_run(action, object_path, kwargs.get('appliance'), **kwargs)
+        if one_target or kwargs.get('appliance') or kwargs.get('specified_target'):
+            return self.do_run(
+                action,
+                object_path,
+                **kwargs
+            )
         else:
             results = []
             for config in self.config['appliance']:

--- a/actions/create_ip_nat_pool.yaml
+++ b/actions/create_ip_nat_pool.yaml
@@ -20,6 +20,9 @@ parameters:
     appliance:
         type: string
         description: The appliance information to connect, which is specified at the 'appliance' parameter in the configuration.
+    specified_target:
+        type: object
+        description: "Specify the target dynamically, (key: 'target', 'api_version', 'userid', 'passwd')"
     pool_name:
         type: string
         description: Pool name or pool group

--- a/actions/del_slb_server.yaml
+++ b/actions/del_slb_server.yaml
@@ -25,3 +25,6 @@ parameters:
         type: string
         description: The appliance information to connect, which is specified at the 'appliance' parameter in the configuration.
         required: true
+    specified_target:
+        type: object
+        description: "Specify the target dynamically, (key: 'target', 'api_version', 'userid', 'passwd')"

--- a/actions/del_slb_server_port.yaml
+++ b/actions/del_slb_server_port.yaml
@@ -36,3 +36,6 @@ parameters:
         type: string
         description: The appliance information to connect, which is specified at the 'appliance' parameter in the configuration.
         required: true
+    specified_target:
+        type: object
+        description: "Specify the target dynamically, (key: 'target', 'api_version', 'userid', 'passwd')"

--- a/actions/del_slb_service_group.yaml
+++ b/actions/del_slb_service_group.yaml
@@ -25,3 +25,6 @@ parameters:
         type: string
         description: The appliance information to connect, which is specified at the 'appliance' parameter in the configuration.
         required: true
+    specified_target:
+        type: object
+        description: "Specify the target dynamically, (key: 'target', 'api_version', 'userid', 'passwd')"

--- a/actions/del_slb_service_group_member.yaml
+++ b/actions/del_slb_service_group_member.yaml
@@ -34,3 +34,6 @@ parameters:
         type: string
         description: The appliance information to connect, which is specified at the 'appliance' parameter in the configuration.
         required: true
+    specified_target:
+        type: object
+        description: "Specify the target dynamically, (key: 'target', 'api_version', 'userid', 'passwd')"

--- a/actions/del_slb_virtual_server.yaml
+++ b/actions/del_slb_virtual_server.yaml
@@ -26,3 +26,6 @@ parameters:
         type: string
         description: The appliance information to connect, which is specified at the 'appliance' parameter in the configuration.
         required: true
+    specified_target:
+        type: object
+        description: "Specify the target dynamically, (key: 'target', 'api_version', 'userid', 'passwd')"

--- a/actions/del_slb_virtual_server_port.yaml
+++ b/actions/del_slb_virtual_server_port.yaml
@@ -67,3 +67,6 @@ parameters:
         type: string
         description: The appliance information to connect, which is specified at the 'appliance' parameter in the configuration.
         required: true
+    specified_target:
+        type: object
+        description: "Specify the target dynamically, (key: 'target', 'api_version', 'userid', 'passwd')"

--- a/actions/delete_ip_nat_pool.yaml
+++ b/actions/delete_ip_nat_pool.yaml
@@ -20,6 +20,9 @@ parameters:
     appliance:
         type: string
         description: The appliance information to connect, which is specified at the 'appliance' parameter in the configuration.
+    specified_target:
+        type: object
+        description: "Specify the target dynamically, (key: 'target', 'api_version', 'userid', 'passwd')"
     name:
         type: string
         description: pool-name to delete IP address of NAT pool

--- a/actions/get_ip_nat_pool.yaml
+++ b/actions/get_ip_nat_pool.yaml
@@ -20,6 +20,9 @@ parameters:
     appliance:
         type: string
         description: The appliance information to connect, which is specified at the 'appliance' parameter in the configuration.
+    specified_target:
+        type: object
+        description: "Specify the target dynamically, (key: 'target', 'api_version', 'userid', 'passwd')"
     name:
         type: string
         description: pool-name to get IP address of NAT pool

--- a/actions/get_slb_server.yaml
+++ b/actions/get_slb_server.yaml
@@ -25,3 +25,6 @@ parameters:
         type: string
         description: The appliance information to connect, which is specified at the 'appliance' parameter in the configuration.
         required: true
+    specified_target:
+        type: object
+        description: "Specify the target dynamically, (key: 'target', 'api_version', 'userid', 'passwd')"

--- a/actions/get_slb_service_group.yaml
+++ b/actions/get_slb_service_group.yaml
@@ -25,3 +25,6 @@ parameters:
         type: string
         description: The appliance information to connect, which is specified at the 'appliance' parameter in the configuration.
         required: true
+    specified_target:
+        type: object
+        description: "Specify the target dynamically, (key: 'target', 'api_version', 'userid', 'passwd')"

--- a/actions/get_slb_service_group_members.yaml
+++ b/actions/get_slb_service_group_members.yaml
@@ -34,3 +34,6 @@ parameters:
         type: string
         description: The appliance information to connect, which is specified at the 'appliance' parameter in the configuration.
         required: true
+    specified_target:
+        type: object
+        description: "Specify the target dynamically, (key: 'target', 'api_version', 'userid', 'passwd')"

--- a/actions/get_slb_virtual_server.yaml
+++ b/actions/get_slb_virtual_server.yaml
@@ -26,3 +26,6 @@ parameters:
         type: string
         description: The appliance information to connect, which is specified at the 'appliance' parameter in the configuration.
         required: true
+    specified_target:
+        type: object
+        description: "Specify the target dynamically, (key: 'target', 'api_version', 'userid', 'passwd')"

--- a/actions/list_ip_nat_pool.yaml
+++ b/actions/list_ip_nat_pool.yaml
@@ -20,3 +20,6 @@ parameters:
     appliance:
         type: string
         description: The appliance information to connect, which is specified at the 'appliance' parameter in the configuration.
+    specified_target:
+        type: object
+        description: "Specify the target dynamically, (key: 'target', 'api_version', 'userid', 'passwd')"

--- a/actions/list_slb_servers.yaml
+++ b/actions/list_slb_servers.yaml
@@ -24,3 +24,6 @@ parameters:
     appliance:
         type: string
         description: The appliance information to connect, which is specified at the 'appliance' parameter in the configuration.
+    specified_target:
+        type: object
+        description: "Specify the target dynamically, (key: 'target', 'api_version', 'userid', 'passwd')"

--- a/actions/list_slb_service_groups.yaml
+++ b/actions/list_slb_service_groups.yaml
@@ -24,3 +24,6 @@ parameters:
     appliance:
         type: string
         description: The appliance information to connect, which is specified at the 'appliance' parameter in the configuration.
+    specified_target:
+        type: object
+        description: "Specify the target dynamically, (key: 'target', 'api_version', 'userid', 'passwd')"

--- a/actions/list_slb_virtual_servers.yaml
+++ b/actions/list_slb_virtual_servers.yaml
@@ -25,3 +25,6 @@ parameters:
     appliance:
         type: string
         description: The appliance information to connect, which is specified at the 'appliance' parameter in the configuration.
+    specified_target:
+        type: object
+        description: "Specify the target dynamically, (key: 'target', 'api_version', 'userid', 'passwd')"

--- a/tests/test_specified_target.py
+++ b/tests/test_specified_target.py
@@ -1,0 +1,69 @@
+import mock
+
+from acos_base_action_test_case import ACOSBaseActionTestCase
+from ax_action_runner import AXActionRunner
+
+
+class SpecifiedTargetTestCase(ACOSBaseActionTestCase):
+    __test__ = True
+    action_cls = AXActionRunner
+
+    def setUp(self):
+        super(SpecifiedTargetTestCase, self).setUp()
+
+        self.action = self.get_action_instance(self._full_config)
+        self.action.logger.addHandler(self._log_handler)
+
+    @mock.patch('acos_client.Client')
+    def test_specified_target_without_one_target(self, mock_client):
+        # set mock of action
+        mock_action = mock.Mock()
+        mock_action.slb.server.get.return_value = 'test-result'
+
+        mock_client.return_value = mock_action
+
+        # execute action
+        params = {
+            'object_path': 'slb.server',
+            'action': 'get',
+            'name': 'hoge',
+            'one_target': False,
+            'specified_target': {
+                'target': 'appliance_acos_v2.1',
+                'userid': 'admin',
+                'passwd': 'hoge',
+                'api_version': 'v2.1',
+            }
+        }
+        result = self.action.run(**params)
+
+        self.assertTrue(result[0])
+        self.assertEqual(result[1], 'test-result')
+        self.assertEqual(len(self._log_handler.messages['error']), 0)
+
+    @mock.patch('acos_client.Client')
+    def test_specified_target_with_one_target(self, mock_client):
+        # set mock of action
+        mock_action = mock.Mock()
+        mock_action.slb.server.get.return_value = 'test-result'
+
+        mock_client.return_value = mock_action
+
+        params = {
+            'object_path': 'slb.server',
+            'action': 'get',
+            'name': 'hoge',
+            'one_target': True,
+            'appliance': 'fuga',
+            'specified_target': {
+                'target': 'appliance_acos_v2.1',
+                'userid': 'admin',
+                'passwd': 'hoge',
+                'api_version': 'v2.1',
+            }
+        }
+        result = self.action.run(**params)
+
+        self.assertTrue(result[0])
+        self.assertEqual(result[1], 'test-result')
+        self.assertEqual(len(self._log_handler.messages['error']), 0)


### PR DESCRIPTION
There are more than 100 LBs in my company's environment.
The number of units increases and decreases frequently, and it is difficult to store all information in st2 settings.

So added the "specified_target" parameter so that can specify the target dynamically.
This parameter is optional and does not affect existing parameters.

Test results are below.
https://github.com/hinashi/stackstorm-acos/actions/runs/2788193100