### PR TITLE
Decouple some features from v1.2.0 to v1.3.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,9 +1,13 @@
 # Changelog
 
-## v1.2.0
+## v1.3.0
+
 * Add `specified_target` parameter to all actions.
-* Added actions to operate IP address of NAT pool
 * Fixed failed action of list slb on v2.1
+
+## v1.2.0
+
+* Added actions to operate IP address of NAT pool
 
 ## v1.1.0
 

--- a/pack.yaml
+++ b/pack.yaml
@@ -7,7 +7,7 @@ keywords:
   - load balancer
   - ADC
   - network
-version: 1.2.0
+version: 1.3.0
 author: Hiroyasu OHYAMA
 email: user.localhost2000@gmail.com
 python_versions:


### PR DESCRIPTION
Some previous Pull Requests (#23, #25) implemented new features with
backword compatibility. But it doesn't bump up pack version. This commit
fix it by separating these features from v1.2.0 to v1.3.0 according to
the Semantic Versioning rule.