### PR TITLE
Enabled to pass parameters how to connect ACOS appliance

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.5.0
+
+* Enabled to pass parameters how to connect ACOS appliance
+
 ## v1.4.0
 
 * Added actions to get slb template lists.

--- a/actions/acoslib/action.py
+++ b/actions/acoslib/action.py
@@ -24,10 +24,19 @@ class BaseAction(Action):
                 config = specified_target
             else:
                 config = next(x for x in self.config['appliance'] if x['target'] == target)
+
+            extra_params = {
+                "max_retries": config.get("max_retries", 3),
+                "port": config.get("port", 443),
+                "protocol": config.get("protocol", "https"),
+                "timeout": config.get("timeout", 5),
+            }
+
             return acos.Client(config['target'],
                                config['api_version'],
                                config['userid'],
-                               config['passwd'])
+                               config['passwd'],
+                               **extra_params)
         except acos.errors.ACOSUnsupportedVersion as e:
             self.logger.error(e)
         except KeyError as e:

--- a/pack.yaml
+++ b/pack.yaml
@@ -7,7 +7,7 @@ keywords:
   - load balancer
   - ADC
   - network
-version: 1.4.0
+version: 1.5.0
 author: Hiroyasu OHYAMA
 email: user.localhost2000@gmail.com
 python_versions:

--- a/tests/test_specified_target.py
+++ b/tests/test_specified_target.py
@@ -16,11 +16,22 @@ class SpecifiedTargetTestCase(ACOSBaseActionTestCase):
 
     @mock.patch('acos_client.Client')
     def test_specified_target_without_one_target(self, mock_client):
-        # set mock of action
-        mock_action = mock.Mock()
-        mock_action.slb.server.get.return_value = 'test-result'
+        def side_effect(*args, **extra_params):
+            # This checks authentication information that is passed to acos.Client
+            self.assertEqual(args, ('appliance_acos_v2.1', 'v2.1', 'admin', 'hoge'))
 
-        mock_client.return_value = mock_action
+            # This checks default extra params are set
+            self.assertEqual(extra_params, {
+                'max_retries': 3, 'port': 443, 'protocol': 'https', 'timeout': 5
+            })
+
+            # set mock of action
+            mock_action = mock.Mock()
+            mock_action.slb.server.get.return_value = 'test-result'
+
+            return mock_action
+
+        mock_client.side_effect = side_effect
 
         # execute action
         params = {
@@ -33,6 +44,48 @@ class SpecifiedTargetTestCase(ACOSBaseActionTestCase):
                 'userid': 'admin',
                 'passwd': 'hoge',
                 'api_version': 'v2.1',
+            }
+        }
+        result = self.action.run(**params)
+
+        self.assertTrue(result[0])
+        self.assertEqual(result[1], 'test-result')
+        self.assertEqual(len(self._log_handler.messages['error']), 0)
+
+    @mock.patch('acos_client.Client')
+    def test_specified_target_with_extra_params(self, mock_client):
+        def side_effect(*args, **extra_params):
+            # This checks authentication information that is passed to acos.Client
+            self.assertEqual(args, ('appliance_acos_v2.1', 'v2.1', 'admin', 'hoge'))
+
+            # This checks extra params are set as user specified
+            self.assertEqual(extra_params, {
+                'max_retries': 10, 'port': 80, 'protocol': 'http', 'timeout': 10
+            })
+
+            # set mock of action
+            mock_action = mock.Mock()
+            mock_action.slb.server.get.return_value = 'test-result'
+
+            return mock_action
+
+        mock_client.side_effect = side_effect
+
+        # execute action
+        params = {
+            'object_path': 'slb.server',
+            'action': 'get',
+            'name': 'hoge',
+            'one_target': False,
+            'specified_target': {
+                'target': 'appliance_acos_v2.1',
+                'userid': 'admin',
+                'passwd': 'hoge',
+                'api_version': 'v2.1',
+                'max_retries': 10,
+                'port': 80,
+                'protocol': 'http',
+                'timeout': 10,
             }
         }
         result = self.action.run(**params)


### PR DESCRIPTION
All actions can't connect an ACOS appliance when its SSL feature is disabled because BaseAction that leads processing to handle acos.Client never pass parameters to manupirate how to connect ACOS appliance.

This commit fixed it to be able to pass those parameters from the "specified_target" parameter that is equipped every action.