### PR TITLE
Added new action to change slb service-group member's configuration that have already been registered + α

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Changelog
 
+
+## v1.6.0
+
+* Added "member_state" parameter at the "acos.acos_slb_service_group_member" action
+  for setting registered member state.
+
 ## v1.5.0
 
 * Enabled to pass parameters how to connect ACOS appliance

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,9 @@
 * Added "member_state" parameter at the "acos.acos_slb_service_group_member" action
   for setting registered member state.
 
+* Added an action "acos.update_slb_service_group_member" to change slb service-group
+  member's configuration that have already been registered.
+
 ## v1.5.0
 
 * Enabled to pass parameters how to connect ACOS appliance

--- a/actions/add_slb_service_group_member.yaml
+++ b/actions/add_slb_service_group_member.yaml
@@ -32,7 +32,14 @@ parameters:
         default: 80
     status:
         type: boolean
-        description: the status of taradd memmber to add
+        description: when 'True' is set, then statical data collection will be enabled
+        enum:
+          - True
+          - False
+        default: True
+    member_state:
+        type: boolean
+        description: when 'True' is set, then member service port will be enabled
         enum:
           - True
           - False

--- a/actions/update_slb_service_group_member.yaml
+++ b/actions/update_slb_service_group_member.yaml
@@ -1,0 +1,54 @@
+---
+name: update_slb_service_group_member
+pack: acos
+runner_type: python-script
+description: update a server to the ServiceGroup as a member
+enabled: true
+entry_point: ax_action_runner.py
+parameters:
+    action:
+        type: string
+        immutable: true
+        default: update
+    object_path:
+        type: string
+        immutable: true
+        default: slb.service_group.member
+    one_target:
+        type: boolean
+        immutable: true
+        default: true
+    service_group_name:
+        type: string
+        description: the ServiceGroup name to register a member
+        required: true
+    server_name:
+        type: string
+        description: the name of server to update
+        default: ''
+    server_port:
+        type: integer
+        description: the port-number of server to update
+        default: 80
+    status:
+        type: boolean
+        description: when 'True' is set, then statical data collection will be enabled
+        enum:
+          - True
+          - False
+        default: True
+    member_state:
+        type: boolean
+        description: when 'True' is set, then member service port will be enabled
+        enum:
+          - True
+          - False
+        default: True
+    appliance:
+        type: string
+        description: The appliance information to connect, which is specified at the 'appliance' parameter in the configuration.
+        required: true
+    specified_target:
+        type: object
+        description: "Specify the target dynamically, (key: 'target', 'api_version', 'userid', 'passwd')"
+

--- a/pack.yaml
+++ b/pack.yaml
@@ -7,7 +7,7 @@ keywords:
   - load balancer
   - ADC
   - network
-version: 1.5.0
+version: 1.6.0
 author: Hiroyasu OHYAMA
 email: user.localhost2000@gmail.com
 python_versions:


### PR DESCRIPTION
This PR has following changes.

### 1. Added new action to change SLB service-group member's configuration that have already been registered.
Added a new action that is corresponding to SLB members update method of `acos-client`.
(c.f. https://github.com/a10networks/acos-client/blob/master/acos_client/v30/slb/member.py#L81)

### 2. Added new parameter "member_state" at the `acos.add_slb_service_group_members` action that could choose enabled/disabled when its member is registered.
In the current implementation "acos.acos_slb_service_group_member" action add member that is always enabled. But there is an use-case that user want to register its member, but doesn't want to be enabled at that time. The [ACOS API](https://acos.docs.a10networks.com/axapi/521/slb_service_group_member.html) and [acos-client library](https://github.com/a10networks/acos-client/blob/master/acos_client/v30/slb/member.py#L75) prepares "member_state" parameter fot that.

This commit added new parameter at "acos.acos_slb_service_group_member" action to be able to select its parameter, "member_state".