### PR TITLE
Enabled to set health_check parameter at the add_slb_server action

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v1.8.0
+* Enabled to set health_check parameter at the add_slb_server action.
+
 ## v1.7.0
 * Added an action (update_slb_virtul_server) to update SLB virtual-server.
 

--- a/actions/add_slb_server.yaml
+++ b/actions/add_slb_server.yaml
@@ -39,3 +39,7 @@ parameters:
     specified_target:
         type: object
         description: "Specify the target dynamically, (key: 'target', 'api_version', 'userid', 'passwd')"
+    health_check:
+        type: string
+        description: name of health monitor for adding Server
+        default: ping

--- a/pack.yaml
+++ b/pack.yaml
@@ -7,7 +7,7 @@ keywords:
   - load balancer
   - ADC
   - network
-version: 1.7.0
+version: 1.8.0
 author: Hiroyasu OHYAMA
 email: user.localhost2000@gmail.com
 python_versions:


### PR DESCRIPTION
## Background / Problem
We can't set `health-check` configuration for added real-server by add_slb_server action because there is no associated parameter to set it. 

## What this changed
The acos-client has feature to set it, so this commit add `health_check` parameter to this action to pass it.

## Execution results

### result of this action
<img width="400" alt="image" src="https://github.com/user-attachments/assets/55c6cad1-609f-434c-9fa6-d4d739179294">

### result of A10 configuration
#### Before
<img width="400" alt="image" src="https://github.com/user-attachments/assets/6b322a29-7cb4-4c5a-aca8-4430b014ea22">

#### After
You can see `health-check` was configured at added slb-server
<img width="400" alt="image" src="https://github.com/user-attachments/assets/e7f42d77-774d-4f8d-b761-6c00ee2d8cad">
